### PR TITLE
CFY-3757 fixed env must contain only strings. Only happened in window…

### DIFF
--- a/script_runner/tasks.py
+++ b/script_runner/tasks.py
@@ -72,6 +72,7 @@ def create_process_config(process, operation_kwargs):
         del env_vars['ctx']
     env_vars.update(process.get('env', {}))
     for k, v in env_vars.items():
+        k = str(k)
         if isinstance(v, (dict, list, set, bool)):
             env_vars[k] = json.dumps(v)
         else:


### PR DESCRIPTION
…s. Converted env keys to strings.